### PR TITLE
Made birth date optional for person

### DIFF
--- a/Person.cs
+++ b/Person.cs
@@ -115,7 +115,7 @@ namespace MXTires.Microdata
         /// </summary>
         /// <value>The birth date.</value>
         [JsonProperty("birthDate")]
-        public DateTime BirthDate { get; set; }
+        public DateTime? BirthDate { get; set; }
 
         /// <summary>
         /// Gets or sets the birth place.


### PR DESCRIPTION
Most places where person is used, only name is mandatory. For example https://developers.google.com/search/docs/data-types/articles where the person is author. I have changed birth date to be optional. 
