### PR TITLE
Allow multiple items on entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,31 @@
 packages/
 Tools/NuGet/mxtires.microdata.1.0.2.2.nupkg/[Content_Types].xml
+
+#ignore thumbnails created by windows
+Thumbs.db
+#Ignore files build by Visual Studio
+*.obj
+*.exe
+*.pdb
+*.user
+*.aps
+*.pch
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.suo
+*.tlb
+*.tlh
+*.bak
+*.cache
+*.ilk
+*.log
+[Bb]in
+[Dd]ebug*/
+*.lib
+*.sbr
+obj/
+[Rr]elease*/
+_ReSharper*/
+[Tt]est[Rr]esult*

--- a/CreativeWorks/Blog.cs
+++ b/CreativeWorks/Blog.cs
@@ -23,6 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
+using System.Collections.Generic;
 using MXTires.Microdata.Validators;
 using Newtonsoft.Json;
 
@@ -36,7 +37,19 @@ namespace MXTires.Microdata.CreativeWorks
         /// <summary>
         /// BlogPosting  - A posting that is part of this blog. Supersedes blogPosts.
         /// </summary>
+        public BlogPosting BlogPost
+        {
+            set
+            {
+                BlogPosts = BlogPosts ?? new List<BlogPosting>();
+                BlogPosts.Add(value);
+            }
+        }
+
+        /// <summary>
+        /// BlogPosting  - The postings that are part of this blog. Supersedes blogPosts.
+        /// </summary>
         [JsonProperty("blogPost")]
-        public BlogPosting BlogPost { get; set; }
+        public List<BlogPosting> BlogPosts { get; set; }
     }
 }

--- a/CreativeWorks/CreativeWork.cs
+++ b/CreativeWorks/CreativeWork.cs
@@ -143,10 +143,22 @@ namespace MXTires.Microdata
         public CreativeWork Citation { get; set; }
 
         /// <summary>
-        /// UserComments  or Comment - Comments, typically from users, on this CreativeWork.
+        /// UserComments  or Comment, typically from users, on this CreativeWork.
+        /// </summary>
+        public object Comment
+        {
+            set
+            {
+                Comments = Comments ?? new List<object>();
+                Comments.Add(value);
+            }
+        }
+
+        /// <summary>
+        /// UserComments  Comments, typically from users, on this CreativeWork.
         /// </summary>
         [JsonProperty("comment")]
-        public object Comment { get; set; }
+        public List<object> Comments { get; set; }
 
         /// <summary>
         /// Integer - The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.

--- a/Intangible/JobPosting.cs
+++ b/Intangible/JobPosting.cs
@@ -73,11 +73,24 @@ namespace MXTires.Microdata.Intangible
         /// </summary>
         [JsonProperty("incentiveCompensation")]
         public string IncentiveCompensation { get; set; }
+
         /// <summary>
         /// Text - The industry associated with the job position.
         /// </summary>
+        public string Industry
+        {
+            set
+            {
+                Industries = Industries ?? new List<string>();
+                Industries.Add(value);
+            }
+        }
+
+        /// <summary>
+        /// Text - The industries associated with the job position.
+        /// </summary>
         [JsonProperty("industry")]
-        public string Industry { get; set; }
+        public List<string> Industries { get; set; }
 
         /// <summary>
         /// Text - Description of benefits associated with the job. Supersedes benefits.

--- a/Intangible/JobPosting.cs
+++ b/Intangible/JobPosting.cs
@@ -24,6 +24,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using MXTires.Microdata.Validators;
 using Newtonsoft.Json;
 
@@ -87,8 +88,20 @@ namespace MXTires.Microdata.Intangible
         /// <summary>
         /// Place - A (typically single) geographic location associated with the job position.
         /// </summary>
+        public Place JobLocation
+        {
+            set
+            {
+                JobLocations = JobLocations ?? new List<Place>();
+                JobLocations.Add(value);
+            }
+        }
+
+        /// <summary>
+        /// Places - Multiple geographic location associated with the job position.
+        /// </summary>
         [JsonProperty("jobLocation")]
-        public Place JobLocation { get; set; }
+        public List<Place> JobLocations { get; set; }
 
         /// <summary>
         /// Text - Category or categories describing the job. Use BLS O*NET-SOC taxonomy: http://www.onetcenter.org/taxonomy.html. Ideally includes textual label and formal code, with the property repeated for each applicable value.

--- a/Organizations/Organization.cs
+++ b/Organizations/Organization.cs
@@ -40,11 +40,23 @@ namespace MXTires.Microdata
         /// <summary>
         /// PostalAddress - Physical address of the item.
         /// </summary>
-        [JsonProperty("address")]
-        public PostalAddress Address { get; set; }
+        public PostalAddress Address
+        {
+            set
+            {
+                Addresses = Addresses ?? new List<PostalAddress>();
+                Addresses.Add(value);
+            }
+        }
 
         /// <summary>
-        /// The location of the event, organization or action.
+        /// PostalAddress - Physical addresses of the item.
+        /// </summary>
+        [JsonProperty("address")]
+        public List<PostalAddress> Addresses { get; set; }
+
+        /// <summary>
+        /// The locations of the event, organization or action.
         /// </summary>
         [JsonProperty("location")]
         public Place Location { get; set; }

--- a/Place.cs
+++ b/Place.cs
@@ -79,8 +79,20 @@ namespace MXTires.Microdata
         /// <summary>
         /// PostalAddress - Physical address of the item.
         /// </summary>
+        public PostalAddress Address
+        {
+            set
+            {
+                Addresses = Addresses ?? new List<PostalAddress>();
+                Addresses.Add(value);
+            }
+        }
+
+        /// <summary>
+        /// PostalAddress - Physical addresses of the item.
+        /// </summary>
         [JsonProperty("address")]
-        public PostalAddress Address { get; set; }
+        public List<PostalAddress> Addresses { get; set; }
 
         /// <summary>
         ///  AggregateRating - The overall rating, based on a collection of reviews or ratings, of the item.

--- a/Places/IPlace.cs
+++ b/Places/IPlace.cs
@@ -17,10 +17,16 @@ namespace MXTires.Microdata.Places
         /// <value>The additional property.</value>
         MXTires.Microdata.Intangible.StructuredValues.PropertyValue AdditionalProperty { get; set; }
         /// <summary>
-        /// Gets or sets the address.
+        /// Sets a single address.
         /// </summary>
         /// <value>The address.</value>
-        PostalAddress Address { get; set; }
+        PostalAddress Address { set; }
+
+        /// <summary>
+        /// Gets or sets a collection of addresses
+        /// </summary>
+        List<PostalAddress> Addresses { get; set; }
+
         /// <summary>
         /// Gets or sets the aggregate rating.
         /// </summary>

--- a/Tests/DemoTests.cs
+++ b/Tests/DemoTests.cs
@@ -24,9 +24,128 @@ namespace MXTires.Microdata.Tests
                 Name = "T3 REPLICA NISSAN ALTIMA, MAXIMA (PAINTED/SILVER)",
             };
             Review review1 = new Review() { Name = "Review1", ReviewRating = new Rating() { RatingValue = "5" }, ReviewBody = "Best product ever!", Author = new Person() { Name = "Some Guy" } };
-            Review review2 = new Review() { Name = "Review2",  ReviewRating = new Rating() { RatingValue = "4" }, ReviewBody = "I've seen better...", Author = new Person() { Name = "Other Guy" } };
+            Review review2 = new Review() { Name = "Review2", ReviewRating = new Rating() { RatingValue = "4" }, ReviewBody = "I've seen better...", Author = new Person() { Name = "Other Guy" } };
             product.Reviews = new List<Review> { review1, review2 };
             System.Diagnostics.Debug.Write(product.ToJson());
+        }
+
+        /// <summary>
+        /// Organization with Multiple Addresses to JSON-LD
+        /// </summary>
+        [TestMethod]
+        public void OrganizationMultipleAddresses()
+        {
+            var org = new Organization()
+            {
+                Name = "My Test Organization",
+                Addresses = new List<PostalAddress>()
+                {
+                    new PostalAddress()
+                    {
+                        Name = "Location 1",
+                        StreetAddress = "123 Somewhere Road",
+                        AddressRegion = "Liverpool",
+                        AddressCountry = "United Kingdom"
+                    },
+                    new PostalAddress()
+                    {
+                        Name = "Location 2",
+                        AddressLocality = "Mountain View",
+                        AddressRegion = "Califronia",
+                        AddressCountry = "USA"
+                    },
+                }
+
+            };
+
+            System.Diagnostics.Debug.Write(org.ToIndentedJson());
+        }
+
+        /// <summary>
+        /// Organization with Single Address to JSON-LD
+        /// </summary>
+        [TestMethod]
+        public void OrganizationSingleAddress()
+        {
+            var org = new Organization()
+            {
+                Name = "My Test Organization",
+                Address = new PostalAddress()
+                {
+                    Name = "Location 1",
+                    StreetAddress = "123 Somewhere Road",
+                    AddressRegion = "Liverpool",
+                    AddressCountry = "United Kingdom"
+                }
+            };
+
+            System.Diagnostics.Debug.Write(org.ToIndentedJson());
+        }
+
+        /// <summary>
+        /// JobPosting with multiple locations to JSON-LD
+        /// </summary>
+        [TestMethod]
+        public void JobPostingMultipleLocation()
+        {
+            var posting = new JobPosting()
+            {
+                Name = "My Job Posting",
+                DatePosted = DateTime.Now,
+                Description = "This is my job description",
+                JobLocations = new List<Place>()
+                {
+                    new Place()
+                    {
+                        Name = "Location 1",
+                        Address = new PostalAddress()
+                        {
+                            Name = "Location 1 House",
+                            AddressRegion = "Liverpool",
+                            AddressCountry = "United Kingdom"
+                        }
+                    },
+                    new Place()
+                    {
+                        Name = "Location 2",
+                        Address = new PostalAddress()
+                        {
+                            Name = "Location 2 House",
+                            AddressRegion = "New York",
+                            AddressCountry = "USA"
+                        }
+                    }
+                }
+            };
+
+            System.Diagnostics.Debug.Write(posting.ToIndentedJson());
+        }
+
+        /// <summary>
+        /// JobPosting with single location to JSON-LD
+        /// </summary>
+        [TestMethod]
+        public void JobPostingSingleLocation()
+        {
+            var posting = new JobPosting()
+            {
+                Name = "My Job Posting",
+                DatePosted = DateTime.Now,
+                Description = "This is my job description",
+                JobLocation = new Place()
+                {
+                    Name = "Location 1",
+                    Address = new PostalAddress()
+                    {
+                        Name = "Location 1 House",
+                        AddressRegion = "Liverpool",
+                        AddressCountry = "United Kingdom"
+                    }
+                }
+
+            };
+
+            System.Diagnostics.Debug.Write(posting.ToIndentedJson());
         }
 
         /// <summary>
@@ -56,10 +175,10 @@ namespace MXTires.Microdata.Tests
                 Telephone = "604-324-5999",
             };
             shop.Location = new Place();
-            shop.Location.Geo = new GeoCoordinates("49.210978", "-123.089581");           
+            shop.Location.Geo = new GeoCoordinates("49.210978", "-123.089581");
 
-            OpeningHoursSpecification mondayHours = new OpeningHoursSpecification("5:30 PM", DaysOfWeek.Mo,"9:00 AM");
-            
+            OpeningHoursSpecification mondayHours = new OpeningHoursSpecification("5:30 PM", DaysOfWeek.Mo, "9:00 AM");
+
             shop.Location.OpeningHoursSpecification = new List<OpeningHoursSpecification>();
             shop.Location.OpeningHoursSpecification.Add(mondayHours);
 
@@ -78,7 +197,7 @@ namespace MXTires.Microdata.Tests
             };
             offer.Availability = ItemAvailability.InStock | ItemAvailability.Discontinued;
             offer.Reviews = new List<Review>();
-            offer.Reviews.Add(new Review() {  ItemReviewed = new Thing(), });
+            offer.Reviews.Add(new Review() { ItemReviewed = new Thing(), });
             offer.AcceptedPaymentMethod = PaymentMethod.VisaCheckout | PaymentMethod.PayPal;
             System.Diagnostics.Debug.WriteLine(offer.ToIndentedJson());
 
@@ -219,9 +338,9 @@ namespace MXTires.Microdata.Tests
         {
             var tire = new Tire() { Name = "T3 Tire" };
 
-            PropertyValue additionalProperty = new PropertyValue(name : "Specs", value : "265/60R18");
+            PropertyValue additionalProperty = new PropertyValue(name: "Specs", value: "265/60R18");
 
-            tire.AdditionalProperty =  additionalProperty ;
+            tire.AdditionalProperty = additionalProperty;
 
             System.Diagnostics.Debug.WriteLine(tire.ToIndentedJson());
 
@@ -249,10 +368,13 @@ namespace MXTires.Microdata.Tests
 
             var eventsList = new ItemList();
             eventsList.ItemListElement = new LinkedList<ListItem>();
-            eventsList.ItemListElement.AddLast(new ListItem() {
-                Item = new MusicEvent() {
-                    Name = "Boz Scaggs", StartDate = "2014-10-10T19:30",
-                    Location = new Place() { Name = "Warner Theatre", Address= new PostalAddress() {AddressLocality = "Washington, DC" } },
+            eventsList.ItemListElement.AddLast(new ListItem()
+            {
+                Item = new MusicEvent()
+                {
+                    Name = "Boz Scaggs",
+                    StartDate = "2014-10-10T19:30",
+                    Location = new Place() { Name = "Warner Theatre", Address = new PostalAddress() { AddressLocality = "Washington, DC" } },
                     Offers = new List<Offer>() { new Offer() { Url = "https://www.etix.com/ticket/1771656" } }
                 },
                 Position = 1
@@ -299,15 +421,15 @@ namespace MXTires.Microdata.Tests
                 ActionStatus = MXTires.Microdata.Intangible.Enumeration.ActionStatusType.PotentialActionStatus,
             };
             webSite.AggregateRating = new AggregateRating()
-                    {
-                        Id= "/SiteAggregateRating",
-                        BestRating = "5",
-                        WorstRating = "1",
-                        RatingValue = "4.6",
-                        ReviewCount = "3500",
-                        Description = "1010tires.com Reviews and Customer Ratings by Shopper Approved.",
-                        Url = "http://www.shopperapproved.com/reviews/1010tires.com/"
-                    };
+            {
+                Id = "/SiteAggregateRating",
+                BestRating = "5",
+                WorstRating = "1",
+                RatingValue = "4.6",
+                ReviewCount = "3500",
+                Description = "1010tires.com Reviews and Customer Ratings by Shopper Approved.",
+                Url = "http://www.shopperapproved.com/reviews/1010tires.com/"
+            };
             System.Diagnostics.Debug.WriteLine(webSite.ToIndentedJson());
         }
 
@@ -315,7 +437,8 @@ namespace MXTires.Microdata.Tests
         /// To test Action
         /// </summary>
         [TestMethod]
-        public void TestChooseAction() {
+        public void TestChooseAction()
+        {
             var action = new ChooseAction();
             action.Option = "text";
             action.Option = new Thing();


### PR DESCRIPTION
Hi. Not sure if you are interested, but I wanted to be able to be able to add multiple items to certain schemas. For example, currently an `Organization` can only have one address (`PostalAddress`). However, it is valid (and desirable) for an `Organization` to have multiple addresses. For instance, this is perfectly valid JSON-LD for an Organization:

```
<script type="application/ld+json">{
  "address": [
    {
      "addressCountry": "United Kingdom",
      "addressRegion": "Liverpool",
      "streetAddress": "123 Somewhere Road",
      "name": "Location 1",
      "@context": "http://schema.org",
      "@type": "PostalAddress"
    },
    {
      "addressCountry": "USA",
      "addressLocality": "Mountain View",
      "addressRegion": "Califronia",
      "name": "Location 2",
      "@context": "http://schema.org",
      "@type": "PostalAddress"
    }
  ],
  "name": "My Test Organization",
  "@context": "http://schema.org",
  "@type": "Organization"
}</script>
```

It validates using https://search.google.com/structured-data/testing-tool

As an example of this I've made a change to `Organization` and `JobPosting` to allow this (whilst still keeping it backward compatible with a single address or location). Here's an example of how I've done this:

```
public PostalAddress Address
{
    set
    {
        Addresses = Addresses ?? new List<PostalAddress>();
        Addresses.Add(value);
    }
}

[JsonProperty("address")]
public List<PostalAddress> Addresses { get; set; }
```

The basic idea is to add an extra `List<T>` collection of multiple items that becomes the main property and then update the old singular property to add the item to the collection. It does mean that even single items are created as an array in the JSON-LD, but I believe this is fine.

Anyway, see what you think. If you think there's a better way, let me know. If you're not interested in this request, I understand, and I'll just maintain my own branch. Cheers!
# 
