### PR TITLE
Feature/thing creativework subclasses

### DIFF
--- a/MXTires.Microdata.csproj
+++ b/MXTires.Microdata.csproj
@@ -542,6 +542,7 @@
     <Compile Include="LocalBusinesses\Stores\TireShop.cs" />
     <Compile Include="Intangible\StructuredValues\TypeAndQuantityNode.cs" />
     <Compile Include="Actions\TradeAction.cs" />
+    <Compile Include="Validators\NamespaceTypes.cs" />
     <Compile Include="Validators\TypeUtil.cs" />
     <Compile Include="Validators\TypeValidator.cs" />
     <Compile Include="Validators\Validator.cs" />

--- a/Person.cs
+++ b/Person.cs
@@ -458,7 +458,7 @@ namespace MXTires.Microdata
         /// <summary>
         /// Sibling of the person. Superseded by <see cref="Sibling"/>.
         /// </summary>
-        [JsonProperty("sibling")]
+        [JsonProperty("siblings")]
         public IList<Person> Siblings { get; set; }
 
         Thing sponsor;

--- a/Tests/DemoTests.cs
+++ b/Tests/DemoTests.cs
@@ -362,6 +362,10 @@ namespace MXTires.Microdata.Tests
         [TestMethod]
         public void EventTest()
         {
+            WebPage webPage = new WebPage();
+            webPage.Id = "/events";
+            webPage.Url = "http://www.1010tires.com/";
+
             var baseEvent = new Event();
             baseEvent.Attendee = new Person();
             System.Diagnostics.Debug.WriteLine(baseEvent.ToIndentedJson());
@@ -399,7 +403,8 @@ namespace MXTires.Microdata.Tests
                 Name = "Boz Scaggs",
                 StartDate = "2015-05-02T20:00",
                 Location = new Place() { Name = "Coral Springs Center for the Performing Arts", Address = new PostalAddress() { AddressLocality = "Coral Springs, FL" } },
-                Offers = new List<Offer>() { new Offer() { Url = "http://frontgatetickets.com/venue.php?id=11766" } }
+                Offers = new List<Offer>() { new Offer() { Url = "http://frontgatetickets.com/venue.php?id=11766" } },
+                MainEntityOfPage = webPage
             };
             System.Diagnostics.Debug.WriteLine(musicEvent.ToString());
         }
@@ -431,6 +436,40 @@ namespace MXTires.Microdata.Tests
                 Url = "http://www.shopperapproved.com/reviews/1010tires.com/"
             };
             System.Diagnostics.Debug.WriteLine(webSite.ToIndentedJson());
+        }
+
+        /// <summary>
+        /// WebSite object to JSON-LD 
+        /// </summary>
+        [TestMethod]
+        public void WebPageTest()
+        {
+            WebSite webSite = new WebSite();
+            webSite.Id = "/";
+            webSite.Url = "http://www.1010tires.com/";
+            webSite.PotentialAction = new SearchAction()
+            {
+                Target = new MXTires.Microdata.Intangible.EntryPoint() { UrlTemplate = "http://www.1010tires.com/Products/Search/?q={q}", },
+                //Query = "required name=q",
+                QueryInput = new PropertyValueSpecification() { ValueName = "q", ValueRequired = true, MultipleValues = true },
+                ActionStatus = MXTires.Microdata.Intangible.Enumeration.ActionStatusType.PotentialActionStatus,
+            };
+            webSite.AggregateRating = new AggregateRating()
+            {
+                Id = "/SiteAggregateRating",
+                BestRating = "5",
+                WorstRating = "1",
+                RatingValue = "4.6",
+                ReviewCount = "3500",
+                Description = "1010tires.com Reviews and Customer Ratings by Shopper Approved.",
+                Url = "http://www.shopperapproved.com/reviews/1010tires.com/"
+            };
+
+            WebPage webPage = new WebPage();
+            webPage.Id = "/events";
+            webPage.Url = "http://www.1010tires.com/";
+            webPage.MainEntityOfPage = webSite;
+            System.Diagnostics.Debug.WriteLine(webPage.ToIndentedJson());
         }
 
         /// <summary>

--- a/Thing.cs
+++ b/Thing.cs
@@ -143,7 +143,7 @@ namespace MXTires.Microdata
             get { return mainEntityOfPage; }
             set
             {
-                var validator = new TypeValidator(typeof(String), typeof(CreativeWork));
+                var validator = new TypeValidator("MXTires.Microdata.CreativeWorks", null, new List<Type>(new Type[] { typeof(String), typeof(WebSite) }));
                 validator.Validate(value);
                 mainEntityOfPage = value;
             }

--- a/Validators/NamespaceTypes.cs
+++ b/Validators/NamespaceTypes.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+
+namespace MXTires.Microdata.Validators
+{
+    class NamespaceTypes
+    {
+        public static List<string> GetClasses(string nameSpace)
+        {
+            Assembly asm = Assembly.GetExecutingAssembly();
+
+            List<string> namespacelist = new List<string>();
+            List<string> classlist = new List<string>();
+
+            foreach (Type type in asm.GetTypes())
+            {
+                if (type.Namespace == nameSpace)
+                    namespacelist.Add(type.Name);
+            }
+
+            foreach (string classname in namespacelist)
+                classlist.Add(classname);
+
+            return classlist;
+        }
+
+        public static List<Type> GetNamespaceTypes(string nameSpace, IList<string> exclude)
+        {
+            Assembly asm = Assembly.GetExecutingAssembly();
+            List<Type> typelist = new List<Type>();
+
+            foreach (Type type in asm.GetTypes())
+            {
+                if (type.Namespace == nameSpace && (exclude == null || exclude.IndexOf(type.Name) == -1))
+                    typelist.Add(type);
+            }
+
+            return typelist;
+        }
+    }
+}

--- a/Validators/TypeValidator.cs
+++ b/Validators/TypeValidator.cs
@@ -67,6 +67,28 @@ namespace MXTires.Microdata.Validators
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="TypeValidator"/> class.
+        /// </summary>
+        /// <param name="typeNamespace">The namespace within all types will be acceptable</param>
+        /// <param name="excludeWithinNamespace">List of type names within the namespace that will be excluded</param>
+        /// <param name="acceptableTypes">List of other types (not from upper namespace) that will be included</param>
+        public TypeValidator(string typeNamespace, IList<string> excludeWithinNamespace, List<Type> acceptableTypes = null)
+        {
+            types = NamespaceTypes.GetNamespaceTypes(typeNamespace, excludeWithinNamespace);
+            if (acceptableTypes != null)
+            {
+                foreach (Type t in acceptableTypes)
+                {
+                    if (!types.Contains(t))
+                    {
+                        types.Add(t);
+                    }
+                }
+
+            }
+        }
+
+        /// <summary>
         /// Determines whether the specified type is valid.
         /// </summary>
         /// <param name="type">The type.</param>


### PR DESCRIPTION
Added a way to include namespace classes in TypeValidator validator. 
This is then used to allow all classes within XTires.Microdata.CreativeWorks namespace to be set on Thing's mainEntityOfPage property.