### PR TITLE
added mainEntity to CreativeWork (according to schema.org specification)

### DIFF
--- a/CreativeWorks/CreativeWork.cs
+++ b/CreativeWorks/CreativeWork.cs
@@ -363,6 +363,12 @@ namespace MXTires.Microdata
         public Thing License { get; set; }
 
         /// <summary>
+        /// Thing - Indicates the primary entity described in some page or other CreativeWork.
+        /// </summary>
+        [JsonProperty("mainEntity")]
+        public Thing MainEntity { get; set; }
+
+        /// <summary>
         /// Thing - Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
         /// </summary>
         [JsonProperty("mentions")]

--- a/Tests/DemoTests.cs
+++ b/Tests/DemoTests.cs
@@ -434,6 +434,25 @@ namespace MXTires.Microdata.Tests
         }
 
         /// <summary>
+        /// WebSite object to JSON-LD 
+        /// </summary>
+        [TestMethod]
+        public void WebPageMainEntityTest()
+        {
+            WebPage webPage = new WebPage();
+            webPage.Id = "/";
+            webPage.Url = "http://www.1010tires.com/";
+            webPage.MainEntity = new MusicEvent()
+            {
+                Name = "Boz Scaggs",
+                StartDate = "2015-05-02T20:00",
+                Location = new Place() { Name = "Coral Springs Center for the Performing Arts", Address = new PostalAddress() { AddressLocality = "Coral Springs, FL" } },
+                Offers = new List<Offer>() { new Offer() { Url = "http://frontgatetickets.com/venue.php?id=11766" } }
+            };
+            System.Diagnostics.Debug.WriteLine(webPage.ToIndentedJson());
+        }
+
+        /// <summary>
         /// To test Action
         /// </summary>
         [TestMethod]

--- a/Tests/DemoTests.cs
+++ b/Tests/DemoTests.cs
@@ -439,7 +439,7 @@ namespace MXTires.Microdata.Tests
         }
 
         /// <summary>
-        /// WebSite object to JSON-LD 
+        /// WebPage object to JSON-LD 
         /// </summary>
         [TestMethod]
         public void WebPageTest()
@@ -469,6 +469,25 @@ namespace MXTires.Microdata.Tests
             webPage.Id = "/events";
             webPage.Url = "http://www.1010tires.com/";
             webPage.MainEntityOfPage = webSite;
+            System.Diagnostics.Debug.WriteLine(webPage.ToIndentedJson());
+        }
+
+        /// <summary>
+        /// WebPage object with mainEntity set to JSON-LD 
+        /// </summary>
+        [TestMethod]
+        public void WebPageMainEntityTest()
+        {
+            WebPage webPage = new WebPage();
+            webPage.Id = "/";
+            webPage.Url = "http://www.1010tires.com/";
+            webPage.MainEntity = new MusicEvent()
+            {
+                Name = "Boz Scaggs",
+                StartDate = "2015-05-02T20:00",
+                Location = new Place() { Name = "Coral Springs Center for the Performing Arts", Address = new PostalAddress() { AddressLocality = "Coral Springs, FL" } },
+                Offers = new List<Offer>() { new Offer() { Url = "http://frontgatetickets.com/venue.php?id=11766" } }
+            };
             System.Diagnostics.Debug.WriteLine(webPage.ToIndentedJson());
         }
 


### PR DESCRIPTION
mainEntity property is added to CreativeWork. This is a standard way to link CreativeWork (usually WebPage) to subclass of Thing